### PR TITLE
feat(preloginselector): allow for preLoginSelectors and wait time

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,18 @@ return cy.task('GoogleSocialLogin', socialLoginOptions).then(({cookies}) => {
 
 Options passed to the task include:
 
-| Option name          | Description                                                                                                           | Example                                 |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| username             |                                                                                                                       |
-| password             |                                                                                                                       |
-| loginUrl             | The URL for the login page that includes the social network buttons                                                   | https://www.example.com/login           |
-| headless             | Whether to run puppeteer in headless more or not                                                                      | true                                    |
-| logs                 | Whether to log interaction with the loginUrl website & cookie data                                                    | false                                   |
-| loginSelector        | A selector on the page that defines the specific social network to use and can be clicked, such as a button or a link | `'a[href="/auth/auth0/google-oauth2"]'` |
-| postLoginSelector    | A selector on the post-login page that can be asserted upon to confirm a successful login                             | `'.account-panel'`                      |
-| getAllBrowserCookies | Whether to get all browser cookies instead of just ones with the domain of loginUrl                                   | true                                    |
+| Option name          | Description                                                                                                                       | Example                                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| username             |                                                                                                                                   |
+| password             |                                                                                                                                   |
+| loginUrl             | The URL for the login page that includes the social network buttons                                                               | https://www.example.com/login           |
+| headless             | Whether to run puppeteer in headless more or not                                                                                  | true                                    |
+| logs                 | Whether to log interaction with the loginUrl website & cookie data                                                                | false                                   |
+| loginSelector        | A selector on the page that defines the specific social network to use and can be clicked, such as a button or a link             | `'a[href="/auth/auth0/google-oauth2"]'` |
+| postLoginSelector    | A selector on the post-login page that can be asserted upon to confirm a successful login                                         | `'.account-panel'`                      |
+| preLoginSelector     | a selector to find and click on before clicking on the login button (useful for accepting cookies)                                | `'.ind-cbar-right button'`              |
+| loginSelectorDelay   | delay a specific amount of time before clicking on the login button, defaults to 250ms. Pass a boolean false to avoid completely. | `100`                                   |
+| getAllBrowserCookies | Whether to get all browser cookies instead of just ones with the domain of loginUrl                                               | true                                    |
 
 ## Install
 

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -8,7 +8,9 @@ const puppeteer = require('puppeteer')
  * @param {options.password} string password
  * @param {options.loginUrl} string password
  * @param {options.loginSelector} string a selector on the loginUrl page for the social provider button
+ * @param {options.loginSelectorDelay} number delay a specific amount of time before clicking on the login button, defaults to 250ms. Pass a boolean false to avoid completely.
  * @param {options.postLoginSelector} string a selector on the app's post-login return page to assert that login is successful
+ * @param {options.preLoginSelector} string a selector to find and click on before clicking on the login button (useful for accepting cookies)
  * @param {options.headless} boolean launch puppeteer in headless more or not
  * @param {options.logs} boolean whether to log cookies and other metadata to console
  * @param {options.getAllBrowserCookies} boolean whether to get all browser cookies instead of just for the loginUrl
@@ -42,7 +44,23 @@ function validateOptions(options) {
 }
 
 async function login({page, options} = {}) {
+  const delay = time => {
+    return new Promise(function(resolve) {
+      setTimeout(resolve, time)
+    })
+  }
+
+  if (options.preLoginSelector) {
+    await page.waitForSelector(options.preLoginSelector)
+    await page.click(options.preLoginSelector)
+  }
+
   await page.waitForSelector(options.loginSelector)
+
+  if (options.loginSelectorDelay !== false) {
+    await delay(options.loginSelectorDelay)
+  }
+
   await page.click(options.loginSelector)
 }
 


### PR DESCRIPTION
## Description

Allows to specify a selector and click for pre-clicking the social login link.
This is usually required when you have cookies to accept or other such prompts on the screen, which also may hide the login button.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
Fixes #13 


