### PR TITLE
fix(headless): implement smart button search

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ describe('Login', () => {
   it('Login through Google', () => {
     const username = Cypress.env('googleSocialLoginUsername')
     const password = Cypress.env('googleSocialLoginPassword')
-
-    const cookieName = Cypress.env('cookieName')
+    const loginUrl = Cypress.env('loginUrl')
+    const cookieName = Cypress.env('cookieName') 
     const socialLoginOptions = {
       username,
       password,
-      loginUrl: Cypress.env('loginUrl'),
+      loginUrl,
       headless: true,
       logs: false,
       loginSelector: 'a[href="/auth/auth0/google-oauth2"]',

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -65,16 +65,22 @@ async function login({page, options} = {}) {
 }
 
 async function typeUsername({page, options} = {}) {
+  const found = (await page.content()).includes('One account. All of Google.')
+  const nextButton = found ? '#next' : '#identifierNext'
+
   await page.waitForSelector('input[type="email"]')
   await page.type('input[type="email"]', options.username)
-  await page.click('#identifierNext')
+  await page.click(nextButton)
 }
 
 async function typePassword({page, options} = {}) {
+  const found = (await page.content()).includes('One account. All of Google.')
+  const signInButton = found ? '#signIn' : '#passwordNext'
+
   await page.waitForSelector('input[type="password"]', {visible: true})
   await page.type('input[type="password"]', options.password)
-  await page.waitForSelector('#passwordNext', {visible: true})
-  await page.click('#passwordNext')
+  await page.waitForSelector(signInButton, {visible: true})
+  await page.click(signInButton)
 }
 
 async function getCookies({page, options} = {}) {

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -18,19 +18,19 @@ const puppeteer = require('puppeteer')
 module.exports.GoogleSocialLogin = async function GoogleSocialLogin(options = {}) {
   validateOptions(options)
 
-  const browser = await puppeteer.launch({headless: !!options.headless})
+  const browser = await puppeteer.launch({ headless: !!options.headless })
   const page = await browser.newPage()
-  await page.setViewport({width: 1280, height: 800})
+  await page.setViewport({ width: 1280, height: 800 })
 
   await page.goto(options.loginUrl)
 
-  await login({page, options})
-  await typeUsername({page, options})
-  await typePassword({page, options})
+  await login({ page, options })
+  await typeUsername({ page, options })
+  await typePassword({ page, options })
 
-  const cookies = await getCookies({page, options})
+  const cookies = await getCookies({ page, options })
 
-  await finalizeSession({page, browser, options})
+  await finalizeSession({ page, browser, options })
 
   return {
     cookies
@@ -43,9 +43,9 @@ function validateOptions(options) {
   }
 }
 
-async function login({page, options} = {}) {
+async function login({ page, options } = {}) {
   const delay = time => {
-    return new Promise(function(resolve) {
+    return new Promise(function (resolve) {
       setTimeout(resolve, time)
     })
   }
@@ -64,26 +64,24 @@ async function login({page, options} = {}) {
   await page.click(options.loginSelector)
 }
 
-async function typeUsername({page, options} = {}) {
-  const found = (await page.content()).includes('One account. All of Google.')
-  const nextButton = found ? '#next' : '#identifierNext'
+async function typeUsername({ page, options } = {}) {
+  let buttonSelector = options.headless ? '#next' : '#identifierNext'
 
   await page.waitForSelector('input[type="email"]')
   await page.type('input[type="email"]', options.username)
-  await page.click(nextButton)
+  await page.click(buttonSelector)
 }
 
-async function typePassword({page, options} = {}) {
-  const found = (await page.content()).includes('One account. All of Google.')
-  const signInButton = found ? '#signIn' : '#passwordNext'
+async function typePassword({ page, options } = {}) {
+  let buttonSelector = options.headless ? '#signIn' : '#passwordNext'
 
-  await page.waitForSelector('input[type="password"]', {visible: true})
+  await page.waitForSelector('input[type="password"]', { visible: true })
   await page.type('input[type="password"]', options.password)
-  await page.waitForSelector(signInButton, {visible: true})
-  await page.click(signInButton)
+  await page.waitForSelector(buttonSelector, { visible: true })
+  await page.click(buttonSelector)
 }
 
-async function getCookies({page, options} = {}) {
+async function getCookies({ page, options } = {}) {
   await page.waitForSelector(options.postLoginSelector)
 
   const cookies = options.getAllBrowserCookies
@@ -102,6 +100,6 @@ async function getCookiesForAllDomains(page) {
   return cookies.cookies
 }
 
-async function finalizeSession({page, browser, options} = {}) {
+async function finalizeSession({ page, browser, options } = {}) {
   await browser.close()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixed an issue for a headless mode.
- Changed the example in the README.md to have all const at the same spot.
- Formatted the document with TSLint rules

## Types of changes

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/lirantal/cypress-social-logins/issues/15

If you run the code as headless it would not work

```
headless: true
```

Then you got an error like:

```
CypressError: cy.task('GoogleSocialLogin') failed with the following error:

> Error: No node found for selector: #identifierNext
    at assert (C:\git\Independer\E2ETests\Cypress\node_modules\puppeteer\lib\helper.js:283:11)
    at DOMWorld.click (C:\git\Independer\E2ETests\Cypress\node_modules\puppeteer\lib\DOMWorld.js:366:5)
    at typeUsername (C:\git\Independer\E2ETests\Cypress\node_modules\cypress-social-logins\src\Plugins.js:70:3)
    at GoogleSocialLogin (C:\git\Independer\E2ETests\Cypress\node_modules\cypress-social-logins\src\Plugins.js:28:3)

  -- ASYNC --
    at Frame.<anonymous> (C:\git\Independer\E2ETests\Cypress\node_modules\puppeteer\lib\helper.js:111:15)
    at Page.click (C:\git\Independer\E2ETests\Cypress\node_modules\puppeteer\lib\Page.js:1067:29)
    at typeUsername (C:\git\Independer\E2ETests\Cypress\node_modules\cypress-social-logins\src\Plugins.js:70:14)
    at GoogleSocialLogin (C:\git\Independer\E2ETests\Cypress\node_modules\cypress-social-logins\src\Plugins.js:28:3)
```

## Motivation and Context

This needed to be changed to run the Cypress script totally headless.

## How Has This Been Tested?

Run the new version headless and non-headless both passed

## Screenshots (if appropriate):

## Checklist:

- [X] I have updated the documentation (if required).
- [X] I have read the **CONTRIBUTING** document.
