### PR TITLE
docs($browser): add troubleshooting case message

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ describe('Login', () => {
 
 Make sure you are providing the plugin with the username or password in the options when instantiating it. If you're passing it via environment variables then the plugin will look for these two: `CYPRESS_googleSocialLoginUsername` and `CYPRESS_googleSocialLoginPassword`
 
+If your application uses popup auth, make sure you are providing `isPopup: true` configuration parameter.
+
 ## Failed to launch the browser process
 
 If you're getting an error on a Linux server such as:


### PR DESCRIPTION
## Description

Adding a new troubleshooting case in readme file, this same error occurs when you have
authentication in popup and it is not set correctly in settings

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/lirantal/cypress-social-logins/issues/34

## Motivation and Context

I had this error for several hours because the ABC parameter was missing, I went directly to the reported issues, however, none refers to a wrong configuration.

## How Has This Been Tested?

Not applicable

## Screenshots (if appropriate):

Not applicable

## Checklist:

- [x ] I have updated the documentation (if required).
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
