### PR TITLE
fix($browser): fix login button selector case

### DIFF
--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -111,11 +111,11 @@ async function typeUsername({page, options} = {}) {
 }
 
 async function typePassword({page, options} = {}) {
-  let buttonSelector = options.headless ? '#signIn' : '#passwordNext'
+  let buttonSelectors = ['#signIn', '#passwordNext', '#submit']
 
   await page.waitForSelector('input[type="password"]', {visible: true})
   await page.type('input[type="password"]', options.password)
-  await page.waitForSelector(buttonSelector, {visible: true})
+  const buttonSelector = await waitForMultipleSelectors(buttonSelectors, {visible: true}, page)
   await page.click(buttonSelector)
 }
 
@@ -140,4 +140,36 @@ async function getCookiesForAllDomains(page) {
 
 async function finalizeSession({page, browser, options} = {}) {
   await browser.close()
+}
+
+async function waitForMultipleSelectors(selectors, options, page) {
+  const navigationOutcome = await racePromises(
+    selectors.map(selector => page.waitForSelector(selector, options))
+  )
+  return selectors[parseInt(navigationOutcome)]
+}
+
+async function racePromises(promises) {
+  const wrappedPromises = []
+  let resolved = false
+  promises.map((promise, index) => {
+    wrappedPromises.push(
+      new Promise(resolve => {
+        promise.then(
+          () => {
+            resolve(index)
+          },
+          error => {
+            if (!resolved) {
+              throw error
+            }
+          }
+        )
+      })
+    )
+  })
+  return Promise.race(wrappedPromises).then(index => {
+    resolved = true
+    return index
+  })
 }


### PR DESCRIPTION
## Description

In Spanish language, the login button selector is different, in this fix, i am wait for multiple possible selector buttons at the same time and the first one found will be used.

I added a controller so that the promises of the other selectors do not generate errors if a promise has already been resolved.

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/lirantal/cypress-social-logins/issues/41

## Motivation and Context

In spanish language, the login button selector are different. More details in Issue report.

## How Has This Been Tested?
- I did tests with multiple selectors in both `headless: true` and `hedless: false` modes.
- I also did a test trying to send all the wrong selectors to see the behavior and this returns the expected error for each promise.
- I changed the order of the selectors so that the ideal selector was last.

## Screenshots (if appropriate):
NA

## Checklist:
- [ ] I have updated the documentation (if required).
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
