### PR TITLE
Make headless mode work more reliably

### DIFF
--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -34,6 +34,12 @@ module.exports.GoogleSocialLogin = async function GoogleSocialLogin(options = {}
   let page = await browser.newPage()
   let originalPageIndex = 1
   await page.setViewport({width: 1280, height: 800})
+  await page.setExtraHTTPHeaders({
+    'Accept-Language': 'en-US;q=0.9,en;q=0.8'
+  })
+  await page.setUserAgent(
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36'
+  )
 
   await page.goto(options.loginUrl)
   await login({page, options})
@@ -107,11 +113,9 @@ async function login({page, options} = {}) {
 }
 
 async function typeUsername({page, options} = {}) {
-  let buttonSelector = options.headless ? '#next' : '#identifierNext'
-
   await page.waitForSelector('input[type="email"]')
   await page.type('input[type="email"]', options.username)
-  await page.click(buttonSelector)
+  await page.click('#identifierNext')
 }
 
 async function typePassword({page, options} = {}) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Running this in the environment of Github Actions, I need the headless mode for puppeteer. Both locally and on Github Actions, setting `headless: true` results in the first step of the login form never completing. When headless is false, it's fine.

This PR adds some headers to the page, which helps Google to render the correct page contents on the first step of the signup flow. Apparently different content is rendered for headless browsers if the correct headers are not present.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/checkly/puppeteer-examples/issues/36

## Motivation and Context


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
