### PR TITLE
fix: 🐛 baseLoginConnect is not defined error

### DIFF
--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -140,12 +140,7 @@ async function racePromises(promises) {
   })
 }
 
-module.exports.baseLoginConnect = async function baseLoginConnect(
-  typeUsername,
-  typePassword,
-  authorizeApp,
-  options
-) {
+async function baseLoginConnect(typeUsername, typePassword, authorizeApp, options) {
   validateOptions(options)
 
   const launchOptions = {headless: !!options.headless}
@@ -212,6 +207,8 @@ module.exports.baseLoginConnect = async function baseLoginConnect(
     ssd
   }
 }
+
+module.exports.baseLoginConnect = baseLoginConnect
 
 module.exports.GoogleSocialLogin = async function GoogleSocialLogin(options = {}) {
   const typeUsername = async function({page, options} = {}) {


### PR DESCRIPTION
baseLoginConnect function couldn't be used in Plugins.js file

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Used cypress-social-logins@1.5.4 and I found this issue of `baseLoginConnect not defined`.
Since this variable is exported directly it wasn't accessible locally

## How Has This Been Tested?

## Screenshots (if appropriate):
![bug](https://user-images.githubusercontent.com/8469804/96280857-214d0800-0ff6-11eb-8afd-8de99cfef83b.png)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
