### PR TITLE
Added option to perform a post login click

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Options passed to the task include:
 | isPopup              | boolean, is your google auth displayed like a popup                                                                               | true                                           |
 | popupDelay           | number, delay a specific milliseconds before popup is shown. Pass a falsy (false, 0, null, undefined, '') to avoid completely     | 2000                                           |
 | cookieDelay          | number, delay a specific milliseconds before get a cookies. Pass a falsy (false, 0, null,undefined,'') to avoid completely        | 100                                            |
+| postLoginClick       | a selector to find and click on after clicking on the login button                                                                | `#idSIButton9`                                 |
 
 ## Install
 

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -141,7 +141,7 @@ async function racePromises(promises) {
   })
 }
 
-async function baseLoginConnect(typeUsername, typePassword, authorizeApp, options) {
+async function baseLoginConnect(typeUsername, typePassword, authorizeApp, postLogin, options) {
   validateOptions(options)
 
   const launchOptions = {headless: !!options.headless}

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -19,6 +19,7 @@ const puppeteer = require('puppeteer')
  * @param {options.isPopup} boolean is your google auth displayed like a popup
  * @param {options.popupDelay} number delay a specific milliseconds before popup is shown. Pass a falsy (false, 0, null, undefined, '') to avoid completely
  * @param {options.cookieDelay} number delay a specific milliseconds before get a cookies. Pass a falsy (false, 0, null, undefined, '') to avoid completely.
+ * @param {options.postLoginClick} string a selector to find and click on after clicking on the login button
  *
  */
 
@@ -180,7 +181,7 @@ async function baseLoginConnect(typeUsername, typePassword, authorizeApp, option
   await typePassword({page, options})
 
   if (options.authorize) {
-    authorizeApp({page, options})
+    await authorizeApp({page, options})
   }
 
   // Switch back to Original Window
@@ -190,6 +191,10 @@ async function baseLoginConnect(typeUsername, typePassword, authorizeApp, option
     }
     const pages = await browser.pages()
     page = pages[originalPageIndex]
+  }
+
+  if (options.postLoginClick) {
+    await postLogin({page, options})
   }
 
   if (options.cookieDelay) {
@@ -227,7 +232,12 @@ module.exports.GoogleSocialLogin = async function GoogleSocialLogin(options = {}
     await page.click(buttonSelector)
   }
 
-  return baseLoginConnect(typeUsername, typePassword, null, options)
+  const postLogin = async function ({page, options} = {}) {
+    await page.waitForSelector(options.postLoginClick)
+    await page.click(options.postLoginClick)
+  }
+
+  return baseLoginConnect(typeUsername, typePassword, null, postLogin, options)
 }
 
 module.exports.GitHubSocialLogin = async function GitHubSocialLogin(options = {}) {
@@ -247,7 +257,12 @@ module.exports.GitHubSocialLogin = async function GitHubSocialLogin(options = {}
     await page.click('button#js-oauth-authorize-btn', options.password)
   }
 
-  return baseLoginConnect(typeUsername, typePassword, authorizeApp, options)
+  const postLogin = async function ({page, options} = {}) {
+    await page.waitForSelector(options.postLoginClick)
+    await page.click(options.postLoginClick)
+  }
+
+  return baseLoginConnect(typeUsername, typePassword, authorizeApp, postLogin, options)
 }
 
 module.exports.MicrosoftSocialLogin = async function MicrosoftSocialLogin(options = {}) {
@@ -270,5 +285,10 @@ module.exports.MicrosoftSocialLogin = async function MicrosoftSocialLogin(option
     await page.click('button#js-oauth-authorize-btn', options.password)
   }
 
-  return baseLoginConnect(typeUsername, typePassword, authorizeApp, options)
+  const postLogin = async function ({page, options} = {}) {
+    await page.waitForSelector(options.postLoginClick)
+    await page.click(options.postLoginClick)
+  }
+
+  return baseLoginConnect(typeUsername, typePassword, authorizeApp, postLogin, options)
 }


### PR DESCRIPTION
Added option to perform a post login click.

## Description

Added a new postLoginClick option that requires a selector, this will be clicked after logging in.
If postLoginClick is not set the function will not be invoked.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context

I found that with Microsoft auth, I was asked if I wanted to be remembered, the new option allows for this to be clicked.

## How Has This Been Tested?

Tested by importing the modified plugin and running a Cypress tests against Microsoft auth.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
