### PR TITLE
feat: provide amazon login as additional provider with onetime password

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Supported identity providers:
 | Google    | GoogleSocialLogin     |
 | GitHub    | GitHubSocialLogin     |
 | Microsoft | MicrosoftSocialLogin  | 
+| Amazon    | AmazonSocialLogin     |
 | Facebook  | TBD                   |
 | Twitter   | TBD                   |
 | LinkedIn  | TBD                   |
@@ -82,6 +83,7 @@ Options passed to the task include:
 | loginSelector        | A selector on the page that defines the specific social network to use and can be clicked, such as a button or a link             | `'a[href="/auth/auth0/google-oauth2"]'`        |
 | postLoginSelector    | A selector on the post-login page that can be asserted upon to confirm a successful login                                         | `'.account-panel'`                             |
 | preLoginSelector     | a selector to find and click on before clicking on the login button (useful for accepting cookies)                                | `'.ind-cbar-right button'`                     |
+| otpSecret            | Secret for generating a otp based on OTPLIB                                                                                       | `'SECRET'`                                     |
 | loginSelectorDelay   | delay a specific amount of time before clicking on the login button, defaults to 250ms. Pass a boolean false to avoid completely. | `100`                                          |
 | getAllBrowserCookies | Whether to get all browser cookies instead of just ones with the domain of loginUrl                                               | true                                           |
 | isPopup              | boolean, is your google auth displayed like a popup                                                                               | true                                           |
@@ -195,6 +197,17 @@ module.exports = (on, config) => {
 }
 ```
 
+## Using AmazonSocialLogin with OneTimePassword
+
+You need a amazon account with activated 2fa. The QR-Code is provided by amazon and contains a SECRET to
+calculate a OTP. This is mandatory due the enforcement of 2fa of new amazon-accounts. SMS or E-Mail is not supported.
+You can extract the Secret from the QR-Code:
+```
+otpauth://totp/Amazon%3ASomeUser%40Example?secret=IBU3VLM........&issuer=Amazon
+```
+You need to setup the account in amazon with GoogleAuthenticator or any password-manager which supports OTP. Further
+information here https://www.amazon.com/gp/help/customer/display.html?nodeId=GE6SLZ5J9GCNRW44
+
 # Troubleshooting
 
 ## Timeout while trying to enter username
@@ -287,6 +300,10 @@ Error: module not found: "ws" from file ..... node_modules/puppeteer/lib/WebSock
 It may be due to the fact that you're requiring one of the exported plugin functions, such as `GoogleSocialLogin` in your spec file in addition to requiring it in `cypress/plugins/index.js`. Remove it from your spec file, or from a `support/index.js` and make sure you export the `GoogleSocialLogin` function as a task only from the `/plugins/index.js` file.
 
 See discussion about [in this issue](https://github.com/lirantal/cypress-social-logins/issues/17).
+
+## Amazon OTP not accepted
+
+Please be aware of proper time on your machine. Make sure you are using ntp to be in sync.
 
 # Author
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,6 +555,48 @@
         "@types/node": ">= 8"
       }
     },
+    "@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA=="
+    },
+    "@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "requires": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "requires": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "requires": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "requires": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -12888,6 +12930,16 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "requires": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "p-each-series": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
@@ -16174,6 +16226,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha1-TKL//AKlEpDSdEueP1V2k8prYno="
     },
     "throat": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "url": "https://github.com/lirantal/cypress-social-logins.git"
   },
   "dependencies": {
+    "otplib": "^12.0.1",
     "puppeteer": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Make use of login with amazon as social login provider.  https://developer.amazon.com/de/apps-and-games/login-with-amazon The only drawback is that you need to setup 2fa for this testuser. The 2fa calculation is done by the otplib and the code is entered before login.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context

The solution was tested as standalone code and now contributed back to the community.

## How Has This Been Tested?

The tests runs in our production app in every build step.

## Screenshots (if appropriate):
<img width="815" alt="Bildschirmfoto 2020-11-16 um 13 17 56" src="https://user-images.githubusercontent.com/4242261/99251802-3ba11e00-280e-11eb-9e5e-0366e96ea3d2.png">
<img width="662" alt="Bildschirmfoto 2020-11-16 um 13 17 31" src="https://user-images.githubusercontent.com/4242261/99251811-3e037800-280e-11eb-8764-22570d927d50.png">



## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
