### PR TITLE
allow preLoginSelector to reside iframe 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,24 +72,26 @@ return cy.task('GoogleSocialLogin', socialLoginOptions).then(({cookies, lsd, ssd
 
 Options passed to the task include:
 
-| Option name          | Description                                                                                                                       | Example                                        |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| username             |                                                                                                                                   |
-| password             |                                                                                                                                   |
-| loginUrl             | The URL for the login page that includes the social network buttons                                                               | https://www.example.com/login                  |
-| args                 | string array which allows providing further arguments to puppeteer                                                                | `['--no-sandbox', '--disable-setuid-sandbox']` |
-| headless             | Whether to run puppeteer in headless mode or not                                                                                  | true                                           |
-| logs                 | Whether to log interaction with the loginUrl website & cookie data                                                                | false                                          |
-| loginSelector        | A selector on the page that defines the specific social network to use and can be clicked, such as a button or a link             | `'a[href="/auth/auth0/google-oauth2"]'`        |
-| postLoginSelector    | A selector on the post-login page that can be asserted upon to confirm a successful login                                         | `'.account-panel'`                             |
-| preLoginSelector     | a selector to find and click on before clicking on the login button (useful for accepting cookies)                                | `'.ind-cbar-right button'`                     |
-| otpSecret            | Secret for generating a otp based on OTPLIB                                                                                       | `'SECRET'`                                     |
-| loginSelectorDelay   | delay a specific amount of time before clicking on the login button, defaults to 250ms. Pass a boolean false to avoid completely. | `100`                                          |
-| getAllBrowserCookies | Whether to get all browser cookies instead of just ones with the domain of loginUrl                                               | true                                           |
-| isPopup              | boolean, is your google auth displayed like a popup                                                                               | true                                           |
-| popupDelay           | number, delay a specific milliseconds before popup is shown. Pass a falsy (false, 0, null, undefined, '') to avoid completely     | 2000                                           |
-| cookieDelay          | number, delay a specific milliseconds before get a cookies. Pass a falsy (false, 0, null,undefined,'') to avoid completely        | 100                                            |
-| postLoginClick       | a selector to find and click on after clicking on the login button                                                                | `#idSIButton9`                                 |
+| Option name                 | Description                                                                                                                       | Example                                        |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| username                    |                                                                                                                                   |
+| password                    |                                                                                                                                   |
+| loginUrl                    | The URL for the login page that includes the social network buttons                                                               | https://www.example.com/login                  |
+| args                        | string array which allows providing further arguments to puppeteer                                                                | `['--no-sandbox', '--disable-setuid-sandbox']` |
+| headless                    | Whether to run puppeteer in headless mode or not                                                                                  | true                                           |
+| logs                        | Whether to log interaction with the loginUrl website & cookie data                                                                | false                                          |
+| loginSelector               | A selector on the page that defines the specific social network to use and can be clicked, such as a button or a link             | `'a[href="/auth/auth0/google-oauth2"]'`        |
+| postLoginSelector           | A selector on the post-login page that can be asserted upon to confirm a successful login                                         | `'.account-panel'`                             |
+| preLoginSelector            | a selector to find and click on before clicking on the login button (useful for accepting cookies)                                | `'.ind-cbar-right button'`                     |
+| preLoginSelectorIframe      | string a selector to find a iframe for the preLoginSelector                                                                       | `'div#consent iframe'`                         |
+| preLoginSelectorIframeDelay | number delay a specific ms after click on the preLoginSelector. Pass a falsy (false, 0, null, undefined, '') to avoid completely. | 2000                                           |
+| otpSecret                   | Secret for generating a otp based on OTPLIB                                                                                       | `'SECRET'`                                     |
+| loginSelectorDelay          | delay a specific amount of time before clicking on the login button, defaults to 250ms. Pass a boolean false to avoid completely. | `100`                                          |
+| getAllBrowserCookies        | Whether to get all browser cookies instead of just ones with the domain of loginUrl                                               | true                                           |
+| isPopup                     | boolean, is your google auth displayed like a popup                                                                               | true                                           |
+| popupDelay                  | number, delay a specific milliseconds before popup is shown. Pass a falsy (false, 0, null, undefined, '') to avoid completely     | 2000                                           |
+| cookieDelay                 | number, delay a specific milliseconds before get a cookies. Pass a falsy (false, 0, null,undefined,'') to avoid completely        | 100                                            |
+| postLoginClick              | a selector to find and click on after clicking on the login button                                                                | `#idSIButton9`                                 |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Options passed to the task include:
 | isPopup                     | boolean, is your google auth displayed like a popup                                                                               | true                                           |
 | popupDelay                  | number, delay a specific milliseconds before popup is shown. Pass a falsy (false, 0, null, undefined, '') to avoid completely     | 2000                                           |
 | cookieDelay                 | number, delay a specific milliseconds before get a cookies. Pass a falsy (false, 0, null,undefined,'') to avoid completely        | 100                                            |
-| postLoginClick              | a selector to find and click on after clicking on the login button                                                                | `#idSIButton9`                                 |
+| postLoginClick              | Optional: a selector to find and click on after clicking on the login button                                                                | `#idSIButton9`                                 |
 
 ## Install
 


### PR DESCRIPTION
## Description

In many cases, consent management systems inject an iframe for consent. the preLoginSelector only allows elements on the same page. Now you can specify a selector for the iframe to search within the preLoginSelector. you also can delay after clicking preLoginSelector because some systems reload the page afterward.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
-
## Motivation and Context

Use of consent management with iframe. 

## How Has This Been Tested?

the feature runs on our production build

## Screenshots (if appropriate):
<img width="582" alt="Bildschirmfoto 2020-11-19 um 10 28 03" src="https://user-images.githubusercontent.com/4242261/99647424-0d138500-2a52-11eb-8585-e9984a753ef5.png">

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
