### PR TITLE
Fix: change selector for facebook login button

### DIFF
--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -367,7 +367,7 @@ module.exports.FacebookSocialLogin = async function FacebookSocialLogin(options 
     await page.type('input[type="password"]', options.password)
 
     // Submit first form
-    await page.click('#loginbutton input')
+    await page.click('#loginbutton')
 
     try {
       // Submit next form


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

![image](https://user-images.githubusercontent.com/24553355/102482626-8d8acd00-4074-11eb-8cc8-c34506b8a582.png)

## Description

After Login via Facebook, cypress stuck trying to find a selector for the login button. 

<img width="372" alt="Снимок экрана 2020-12-17 в 14 32 33" src="https://user-images.githubusercontent.com/24553355/102482722-b6ab5d80-4074-11eb-9481-a3f96b6d5ee7.png">

the main issue, there is a different selector.

<img width="1046" alt="Снимок экрана 2020-12-17 в 14 25 29" src="https://user-images.githubusercontent.com/24553355/102482075-b9598300-4073-11eb-9ed6-487ef3133056.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

- Follow instructions from https://next-auth.js.org/tutorials/testing-with-cypress to set up basic login test. 
- Change your settings from GoogleSocialLogin to FacebookSocialLogin. 
- Change socialLoginOprions.headless to false to see a popup of facebook while the test is running
- Open dev-tools and ensure that selector is wrong

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun
