### PR TITLE
optional login selector

### DIFF
--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -59,13 +59,15 @@ async function login({page, options} = {}) {
     }
   }
 
-  await page.waitForSelector(options.loginSelector)
+  if (options.loginSelector) {
+    await page.waitForSelector(options.loginSelector)
 
-  if (options.loginSelectorDelay !== false) {
-    await delay(options.loginSelectorDelay)
+    if (options.loginSelectorDelay !== false) {
+      await delay(options.loginSelectorDelay)
+    }
+
+    await page.click(options.loginSelector)
   }
-
-  await page.click(options.loginSelector)
 }
 
 async function getCookies({page, options} = {}) {


### PR DESCRIPTION
Made optional field loginSelector

## Description

Sometimes, you'll get a social login page during redirections from specific links. In that cases you don't need to click any social providers buttons at all. But as loginSelector is not optional, in cases of redirections you have to fill it with any fake locators. This fix provides not to set the locator if social login page should appear as a result of redirection actions.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/lirantal/cypress-social-logins/issues/82

## Motivation and Context

Provides not to set fake locators, if they are not required.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
Local run in my testing project

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun
