### PR TITLE
feat($browser): add screen-capture on error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Options passed to the task include:
 | usernameSubmitBtn | Optional for CustomizedLogin: string, a selector for the username button  | | 
 | passwordField | Required for CustomizedLogin: string, a selector for the password field | | 
 | passwordSubmitBtn | Optional for CustomizedLogin: string, a selector for password submit button | |
+| screenshotOnError | Optional: will grab a screen shot if an error occurs on the username, password, or post-login page and saves in the Cypress screenshots folder.     | false |
 | additionalSteps             | Optional: function, to define any additional steps which may be required after executing functions for username and password, such as answering security questions, PIN, or anything which may be required to fill out after username and password process. The function and this property must be defined or referenced from index.js for Cypress Plugins directory. | `async function moreSteps({page, options} = {}) { await page.waitForSelector('#pin_Field') await page.click('#pin_Field')  }` |
 
 ## Install

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -3,6 +3,7 @@
 
 const puppeteer = require('puppeteer')
 const authenticator = require('otplib').authenticator
+const fs = require('fs')
 
 /**
  *
@@ -29,6 +30,7 @@ const authenticator = require('otplib').authenticator
  * @param {options.passwordField} string selector for the password field
  * @param {options.passwordSubmitBtn} string selector password submit button
  * @param {options.additionalSteps} function any additional func which may be required for signin step after username and password
+ * @param {options.screenshotOnError} boolean grab a screenshot if an error occurs during username, password, or post-login page
  *
  */
 
@@ -42,6 +44,15 @@ function validateOptions(options) {
   if (!options.username || !options.password) {
     throw new Error('Username or Password missing for social login')
   }
+}
+
+function takeScreenshot(options) {
+  if (options.screenshotOnError) {
+    if (!fs.existsSync('./cypress/screenshots/cypresssociallogin/')) {
+      fs.mkdirSync('./cypress/screenshots/cypresssociallogin/', {recursive: true})
+    }
+  }
+  page.screenshot({path: `'./cypress/screenshots/cypresssociallogin/socialLoginError.png`})
 }
 
 async function login({page, options} = {}) {
@@ -252,24 +263,39 @@ module.exports.baseLoginConnect = baseLoginConnect
 
 module.exports.GoogleSocialLogin = async function GoogleSocialLogin(options = {}) {
   const typeUsername = async function({page, options} = {}) {
-    await page.waitForSelector('input#identifierId[type="email"]')
-    await page.type('input#identifierId[type="email"]', options.username)
-    await page.click('#identifierNext')
+    try {
+      await page.waitForSelector('input#identifierId[type="email"]')
+      await page.type('input#identifierId[type="email"]', options.username)
+      await page.click('#identifierNext')
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   const typePassword = async function({page, options} = {}) {
-    let buttonSelectors = ['#signIn', '#passwordNext', '#submit']
+    try {
+      let buttonSelectors = ['#signIn', '#passwordNext', '#submit']
 
-    await page.waitForSelector('input[type="password"]', {visible: true})
-    await page.type('input[type="password"]', options.password)
+      await page.waitForSelector('input[type="password"]', {visible: true})
+      await page.type('input[type="password"]', options.password)
 
-    const buttonSelector = await waitForMultipleSelectors(buttonSelectors, {visible: true}, page)
-    await page.click(buttonSelector)
+      const buttonSelector = await waitForMultipleSelectors(buttonSelectors, {visible: true}, page)
+      await page.click(buttonSelector)
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   const postLogin = async function({page, options} = {}) {
-    await page.waitForSelector(options.postLoginClick)
-    await page.click(options.postLoginClick)
+    try {
+      await page.waitForSelector(options.postLoginClick)
+      await page.click(options.postLoginClick)
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   return baseLoginConnect(typeUsername, typePassword, null, null, postLogin, options)
@@ -277,14 +303,24 @@ module.exports.GoogleSocialLogin = async function GoogleSocialLogin(options = {}
 
 module.exports.GitHubSocialLogin = async function GitHubSocialLogin(options = {}) {
   const typeUsername = async function({page, options} = {}) {
-    await page.waitForSelector('input#login_field')
-    await page.type('input#login_field', options.username)
+    try {
+      await page.waitForSelector('input#login_field')
+      await page.type('input#login_field', options.username)
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   const typePassword = async function({page, options} = {}) {
-    await page.waitForSelector('input#password', {visible: true})
-    await page.type('input#password', options.password)
-    await page.click('input[type="submit"]')
+    try {
+      await page.waitForSelector('input#password', {visible: true})
+      await page.type('input#password', options.password)
+      await page.click('input[type="submit"]')
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   const authorizeApp = async function({page, options} = {}) {
@@ -293,8 +329,13 @@ module.exports.GitHubSocialLogin = async function GitHubSocialLogin(options = {}
   }
 
   const postLogin = async function({page, options} = {}) {
-    await page.waitForSelector(options.postLoginClick)
-    await page.click(options.postLoginClick)
+    try {
+      await page.waitForSelector(options.postLoginClick)
+      await page.click(options.postLoginClick)
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   return baseLoginConnect(typeUsername, typePassword, null, authorizeApp, postLogin, options)
@@ -302,17 +343,27 @@ module.exports.GitHubSocialLogin = async function GitHubSocialLogin(options = {}
 
 module.exports.MicrosoftSocialLogin = async function MicrosoftSocialLogin(options = {}) {
   const typeUsername = async function({page, options} = {}) {
-    await page.waitForSelector('input[type="email"]')
-    await page.type('input[type="email"]', options.username)
-    await page.click('input[type="submit"]')
+    try {
+      await page.waitForSelector('input[type="email"]')
+      await page.type('input[type="email"]', options.username)
+      await page.click('input[type="submit"]')
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   const typePassword = async function({page, options} = {}) {
-    await delay(5000)
+    try {
+      await delay(5000)
 
-    await page.waitForSelector('input[type="password"]', {visible: true})
-    await page.type('input[type="password"]', options.password)
-    await page.click('input[type="submit"]')
+      await page.waitForSelector('input[type="password"]', {visible: true})
+      await page.type('input[type="password"]', options.password)
+      await page.click('input[type="submit"]')
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   const authorizeApp = async function({page, options} = {}) {
@@ -321,8 +372,13 @@ module.exports.MicrosoftSocialLogin = async function MicrosoftSocialLogin(option
   }
 
   const postLogin = async function({page, options} = {}) {
-    await page.waitForSelector(options.postLoginClick)
-    await page.click(options.postLoginClick)
+    try {
+      await page.waitForSelector(options.postLoginClick)
+      await page.click(options.postLoginClick)
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   return baseLoginConnect(typeUsername, typePassword, null, authorizeApp, postLogin, options)
@@ -330,18 +386,28 @@ module.exports.MicrosoftSocialLogin = async function MicrosoftSocialLogin(option
 
 module.exports.AmazonSocialLogin = async function AmazonSocialLogin(options = {}) {
   const typeUsername = async function({page, options} = {}) {
-    await page.waitForSelector('#ap_email', {visible: true})
-    await page.type('#ap_email', options.username)
+    try {
+      await page.waitForSelector('#ap_email', {visible: true})
+      await page.type('#ap_email', options.username)
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   const typePassword = async function({page, options} = {}) {
     let buttonSelectors = ['#signInSubmit']
 
-    await page.waitForSelector('input[type="password"]', {visible: true})
-    await page.type('input[type="password"]', options.password)
+    try {
+      await page.waitForSelector('input[type="password"]', {visible: true})
+      await page.type('input[type="password"]', options.password)
 
-    const buttonSelector = await waitForMultipleSelectors(buttonSelectors, {visible: true}, page)
-    await page.click(buttonSelector)
+      const buttonSelector = await waitForMultipleSelectors(buttonSelectors, {visible: true}, page)
+      await page.click(buttonSelector)
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   const otpApp = async function({page, options} = {}) {
@@ -359,17 +425,27 @@ module.exports.AmazonSocialLogin = async function AmazonSocialLogin(options = {}
 
 module.exports.FacebookSocialLogin = async function FacebookSocialLogin(options = {}) {
   const typeUsername = async function({page, options} = {}) {
-    const emailSelector = '#email'
-    await page.waitForSelector(emailSelector)
-    await page.type(emailSelector, options.username)
+    try {
+      const emailSelector = '#email'
+      await page.waitForSelector(emailSelector)
+      await page.type(emailSelector, options.username)
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   const typePassword = async function({page, options} = {}) {
-    await page.waitForSelector('input[type="password"]', {visible: true})
-    await page.type('input[type="password"]', options.password)
+    try {
+      await page.waitForSelector('input[type="password"]', {visible: true})
+      await page.type('input[type="password"]', options.password)
 
-    // Submit first form
-    await page.click('#loginbutton')
+      // Submit first form
+      await page.click('#loginbutton')
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
 
     try {
       // Submit next form
@@ -382,8 +458,13 @@ module.exports.FacebookSocialLogin = async function FacebookSocialLogin(options 
   }
 
   const postLogin = async function({page, options} = {}) {
-    await page.waitForSelector(options.postLoginClick)
-    await page.click(options.postLoginClick)
+    try {
+      await page.waitForSelector(options.postLoginClick)
+      await page.click(options.postLoginClick)
+    } catch (err) {
+      takeScreenshot(options)
+      throw err
+    }
   }
 
   return baseLoginConnect(typeUsername, typePassword, null, null, postLogin, options)
@@ -392,22 +473,37 @@ module.exports.FacebookSocialLogin = async function FacebookSocialLogin(options 
 module.exports.CustomizedLogin = async function CustomizedLogin(options = {}) {
   if (options.usernameField && options.passwordField) {
     const typeUsername = async function({page, options} = {}) {
-      await page.waitForSelector(options.usernameField, {visible: true})
-      await page.type(options.usernameField, options.username)
-      if (options.usernameSubmitBtn) {
-        await page.click(options.usernameSubmitBtn)
+      try {
+        await page.waitForSelector(options.usernameField, {visible: true})
+        await page.type(options.usernameField, options.username)
+        if (options.usernameSubmitBtn) {
+          await page.click(options.usernameSubmitBtn)
+        }
+      } catch (err) {
+        takeScreenshot(options)
+        throw err
       }
     }
     const typePassword = async function({page, options} = {}) {
-      await page.waitForSelector(options.passwordField, {visible: true})
-      await page.type(options.passwordField, options.password)
-      if (options.passwordSubmitBtn) {
-        await page.click(options.passwordSubmitBtn)
+      try {
+        await page.waitForSelector(options.passwordField, {visible: true})
+        await page.type(options.passwordField, options.password)
+        if (options.passwordSubmitBtn) {
+          await page.click(options.passwordSubmitBtn)
+        }
+      } catch (err) {
+        takeScreenshot(options)
+        throw err
       }
     }
     const postLogin = async function({page, options} = {}) {
-      await page.waitForSelector(options.postLoginClick)
-      await page.click(options.postLoginClick)
+      try {
+        await page.waitForSelector(options.postLoginClick)
+        await page.click(options.postLoginClick)
+      } catch (err) {
+        takeScreenshot(options)
+        throw err
+      }
     }
     return baseLoginConnect(typeUsername, typePassword, null, null, postLogin, options)
   } else {

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -51,8 +51,8 @@ function takeScreenshot(options) {
     if (!fs.existsSync('./cypress/screenshots/cypresssociallogin/')) {
       fs.mkdirSync('./cypress/screenshots/cypresssociallogin/', {recursive: true})
     }
+    page.screenshot({path: `'./cypress/screenshots/cypresssociallogin/SocialLoginError.png`})
   }
-  page.screenshot({path: `'./cypress/screenshots/cypresssociallogin/socialLoginError.png`})
 }
 
 async function login({page, options} = {}) {


### PR DESCRIPTION
add screen-capture on error for username, password, and post-login behavior

## Description

Added try/catches around username, password, and post-login events that, on an error, call a screen-capture function. I was going to make the directory variable, but ESLint didn't like that a directory could be editable by the user so I dropped that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/lirantal/cypress-social-logins/issues/85

## Motivation and Context

When running cypress-social-login with a headed pop-up remotely any errors are not caught by Cypress screen captures. Local runs may not catch CAPTCHA requests or MFA which are occurring remotely and these are difficult to verify from the normal Cypress "missing locator" error.

## How Has This Been Tested?

local runs for my tests

## Screenshots (if appropriate):

## Checklist:

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun (I don't have one, sorry!)
