### PR TITLE
fix($screenshot): fixed screenshot for non-customized logins

### DIFF
--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -46,7 +46,7 @@ function validateOptions(options) {
   }
 }
 
-function takeScreenshot(options) {
+function takeScreenshot(page, options) {
   if (options.screenshotOnError) {
     if (!fs.existsSync('./cypress/screenshots/cypresssociallogin/')) {
       fs.mkdirSync('./cypress/screenshots/cypresssociallogin/', {recursive: true})
@@ -268,7 +268,7 @@ module.exports.GoogleSocialLogin = async function GoogleSocialLogin(options = {}
       await page.type('input#identifierId[type="email"]', options.username)
       await page.click('#identifierNext')
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -283,7 +283,7 @@ module.exports.GoogleSocialLogin = async function GoogleSocialLogin(options = {}
       const buttonSelector = await waitForMultipleSelectors(buttonSelectors, {visible: true}, page)
       await page.click(buttonSelector)
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -293,7 +293,7 @@ module.exports.GoogleSocialLogin = async function GoogleSocialLogin(options = {}
       await page.waitForSelector(options.postLoginClick)
       await page.click(options.postLoginClick)
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -307,7 +307,7 @@ module.exports.GitHubSocialLogin = async function GitHubSocialLogin(options = {}
       await page.waitForSelector('input#login_field')
       await page.type('input#login_field', options.username)
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -318,7 +318,7 @@ module.exports.GitHubSocialLogin = async function GitHubSocialLogin(options = {}
       await page.type('input#password', options.password)
       await page.click('input[type="submit"]')
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -333,7 +333,7 @@ module.exports.GitHubSocialLogin = async function GitHubSocialLogin(options = {}
       await page.waitForSelector(options.postLoginClick)
       await page.click(options.postLoginClick)
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -348,7 +348,7 @@ module.exports.MicrosoftSocialLogin = async function MicrosoftSocialLogin(option
       await page.type('input[type="email"]', options.username)
       await page.click('input[type="submit"]')
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -361,7 +361,7 @@ module.exports.MicrosoftSocialLogin = async function MicrosoftSocialLogin(option
       await page.type('input[type="password"]', options.password)
       await page.click('input[type="submit"]')
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -376,7 +376,7 @@ module.exports.MicrosoftSocialLogin = async function MicrosoftSocialLogin(option
       await page.waitForSelector(options.postLoginClick)
       await page.click(options.postLoginClick)
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -390,7 +390,7 @@ module.exports.AmazonSocialLogin = async function AmazonSocialLogin(options = {}
       await page.waitForSelector('#ap_email', {visible: true})
       await page.type('#ap_email', options.username)
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -405,7 +405,7 @@ module.exports.AmazonSocialLogin = async function AmazonSocialLogin(options = {}
       const buttonSelector = await waitForMultipleSelectors(buttonSelectors, {visible: true}, page)
       await page.click(buttonSelector)
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -430,7 +430,7 @@ module.exports.FacebookSocialLogin = async function FacebookSocialLogin(options 
       await page.waitForSelector(emailSelector)
       await page.type(emailSelector, options.username)
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -443,7 +443,7 @@ module.exports.FacebookSocialLogin = async function FacebookSocialLogin(options 
       // Submit first form
       await page.click('#loginbutton')
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
 
@@ -462,7 +462,7 @@ module.exports.FacebookSocialLogin = async function FacebookSocialLogin(options 
       await page.waitForSelector(options.postLoginClick)
       await page.click(options.postLoginClick)
     } catch (err) {
-      takeScreenshot(options)
+      takeScreenshot(page, options)
       throw err
     }
   }
@@ -480,7 +480,7 @@ module.exports.CustomizedLogin = async function CustomizedLogin(options = {}) {
           await page.click(options.usernameSubmitBtn)
         }
       } catch (err) {
-        takeScreenshot(options)
+        takeScreenshot(page, options)
         throw err
       }
     }
@@ -492,7 +492,7 @@ module.exports.CustomizedLogin = async function CustomizedLogin(options = {}) {
           await page.click(options.passwordSubmitBtn)
         }
       } catch (err) {
-        takeScreenshot(options)
+        takeScreenshot(page, options)
         throw err
       }
     }
@@ -501,7 +501,7 @@ module.exports.CustomizedLogin = async function CustomizedLogin(options = {}) {
         await page.waitForSelector(options.postLoginClick)
         await page.click(options.postLoginClick)
       } catch (err) {
-        takeScreenshot(options)
+        takeScreenshot(page, options)
         throw err
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

screenshot was not receiving the page object in non-customized logins and would fail

<!--- Describe your changes in detail -->

Updated takeScreenshot to include page and all calling functions to pass it.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/lirantal/cypress-social-logins/issues/85

## Motivation and Context

People who want to use the screenshot option but aren't using custom login controls

## How Has This Been Tested?

Originally I just tested against my customized login. Now I've tested against custom and GoogleSocialLogin. Works as expected for both now!

## Screenshots (if appropriate):

![5953F913-F297-4F7C-B3FA-94814C736E7B_1_201_a](https://user-images.githubusercontent.com/65390479/108899650-8381cf00-75cd-11eb-90f9-27c7ec990460.jpeg)
Taken with GoogleSocialLogin

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun

![image](https://user-images.githubusercontent.com/65390479/108899829-bcba3f00-75cd-11eb-8837-6d8682f0d555.png)

