### PR TITLE
Feat/accept third party cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Options passed to the task include:
 | passwordSubmitBtn | Optional for CustomizedLogin: string, a selector for password submit button | |
 | screenshotOnError | Optional: will grab a screen shot if an error occurs on the username, password, or post-login page and saves in the Cypress screenshots folder.     | false |
 | additionalSteps             | Optional: function, to define any additional steps which may be required after executing functions for username and password, such as answering security questions, PIN, or anything which may be required to fill out after username and password process. The function and this property must be defined or referenced from index.js for Cypress Plugins directory. | `async function moreSteps({page, options} = {}) { await page.waitForSelector('#pin_Field') await page.click('#pin_Field')  }` |
+| trackingConsentSelectors  | Optional: selectors to find and click on after clicking the login button, but before entering details on the third-party site (useful for accepting third-party cookies e.g. Facebook login). Provide multiple if wanting to accept only essential cookies and it requires multiple clicks |  `['button[data-testid="cookie-policy-dialog-manage-button"]', 'button-data-testid="cookie-policy-manage-dialog-accept-button"]']` |
 
 ## Install
 

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -31,6 +31,7 @@ const fs = require('fs')
  * @param {options.passwordSubmitBtn} string selector password submit button
  * @param {options.additionalSteps} function any additional func which may be required for signin step after username and password
  * @param {options.screenshotOnError} boolean grab a screenshot if an error occurs during username, password, or post-login page
+ * @param {options.trackingConsentSelectors} array[string] selectors to find and click on before entering details on the third-party site (useful for accepting third-party cookies)
  *
  */
 
@@ -213,6 +214,14 @@ async function baseLoginConnect(
       pages.find(p => page._target._targetId === p._target._targetId)
     )
     page = pages[pages.length - 1]
+  }
+
+  // Accept third-party cookies if required
+  if (options.trackingConsentSelectors !== undefined) {
+    for (const selector of options.trackingConsentSelectors) {
+      await page.waitForSelector(selector)
+      await page.click(selector)
+    }
   }
 
   await typeUsername({page, options})


### PR DESCRIPTION
## Description

 Similar behaviour is available using preLoginSelector, however this only works for accepting cookies on the user's application. This change:
 - allows configuring multiple additional selectors, which will be used after the initial login click, but before attempting to enter third-party credentials
 - allows a user to configure the plugin to click third-party GDPR-related warnings, for example those seen on Facebook

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
https://github.com/lirantal/cypress-social-logins/issues/27

## Motivation and Context

Trying to test a more-complicated login flow, where clicking the `login` button with existing React state may send additional context on the backend, e.g. for linking existing accounts. As a result I don't think I'm able to navigate directly to `/api/auth/signin/facebook`, instead I want to go to `/api/auth/signin` and use a selector to find the 'Facebook' button.

## How Has This Been Tested?
Tested as part of integrating in my own project.

For example, took accept only essential cookies on Facebook:
```js
const socialLoginOptions = {
  username,
  password,
  ...,
  loginSelector: 'form[action="http://localhost:3000/api/auth/signin/facebook"] > button[type="submit"]',
  trackingConsentSelectors: [
    'button[data-testid="cookie-policy-dialog-manage-button"]',
    'button[data-testid="cookie-policy-manage-dialog-accept-button"]'
  ]
}
cy.task('FacebookSocialLogin', socialLoginOptions).then(({ cookies, lsd, ssd }) => {
  ...
}
```

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/8646034/142740006-3352198b-2306-4007-b4c5-2a3e601509cd.png)


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
