### PR TITLE
Feature: Add Basic Authentication for loginUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Options passed to the task include:
 | username                    |                                                                                                                                   |
 | password                    |                                                                                                                                   |
 | loginUrl                    | The URL for the login page that includes the social network buttons                                                               | https://www.example.com/login                  |
+| loginUrlCredentials         | Basic Authentication credentials for the `loginUrl`                                                                               | `{username: user, password: demo}`             |
 | args                        | string array which allows providing further arguments to puppeteer                                                                | `['--no-sandbox', '--disable-setuid-sandbox']` |
 | headless                    | Whether to run puppeteer in headless mode or not                                                                                  | true                                           |
 | logs                        | Whether to log interaction with the loginUrl website & cookie data                                                                | false                                          |

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -10,6 +10,7 @@ const fs = require('fs')
  * @param {options.username} string username
  * @param {options.password} string password
  * @param {options.loginUrl} string password
+ * @param {options.loginUrlCredentials} Object Basic Authentication credentials for the `loginUrl`
  * @param {options.args} array[string] string array which allows providing further arguments to puppeteer
  * @param {options.loginSelector} string a selector on the loginUrl page for the social provider button
  * @param {options.loginSelectorDelay} number delay a specific amount of time before clicking on the login button, defaults to 250ms. Pass a boolean false to avoid completely.
@@ -199,7 +200,9 @@ async function baseLoginConnect(
   await page.setUserAgent(
     'Mozilla/5.0 (Windows NT 10.0 Win64 x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36'
   )
-
+  if (options.loginUrlCredentials) {
+    await page.authenticate(options.loginUrlCredentials)
+  }
   await page.goto(options.loginUrl)
   await login({page, options})
 


### PR DESCRIPTION
Add `loginUrlCredentials` config to provide Basic Authentication.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Allow an optional `loginUrlCredentials` config which provides basic authentication credentials when
visiting `loginUrl`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#109 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested this against a site which required Basic Authentication, as well as tested against a site which did not require authentication.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun

![image](https://user-images.githubusercontent.com/1437534/145622894-1e94d619-2067-4012-b7c0-0c8f530398c6.png)

