### PR TITLE
Fix exports for ES6 modules

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
-import * as Plugins from "./Plugins";
+import * as plugins from "./Plugins";
 
 declare module "cypress-social-logins" {
-    export {Plugins}
+    export { plugins };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hi, I experienced errors using the `Plugins` because what you export from the index.js file is not `{ Plugins }` but `{ plugins }`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Related to https://github.com/lirantal/cypress-social-logins/issues/114

## Motivation and Context

Just want to make it work with ES6.

## How Has This Been Tested?

It's just a change in exported TS types.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
